### PR TITLE
FIX/typo in gemini api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ bun install
 Create a `.env` file inside the `agent` folder with the following content:
 
 ```
-GEMENI_API_KEY=sk-...your-openai-key-here...
+GEMINI_API_KEY=sk-...your-openai-key-here...
 ```
 
 


### PR DESCRIPTION
I was following the instruction in the README and I got this error due to a typo in the gemini api key

```bash
[augustin@nixos:~/Documents/with-a2a-a2ui]$ ./scripts/run-agent.sh
ERROR:__main__:Error: GEMINI_API_KEY environment variable not set and GOOGLE_GENAI_USE_VERTEXAI is not TRUE.

```